### PR TITLE
chore: ignore the `package-lock.json` file when using the `pnpm` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage
 
 # vitepress
 docs/.vitepress/cache
+package-lock.json


### PR DESCRIPTION
depends on #62 being closed.

running `npm install` generates the `package-lock.json` file.
Since we will use `pnpm-lock.yml` _(as lockfile)_ we can ignore the `package-lock.json` file from being committed.